### PR TITLE
Update contents as of 2023-09-08

### DIFF
--- a/content/2023/committee.md
+++ b/content/2023/committee.md
@@ -45,8 +45,8 @@ Industry Chairs
 Web Chairs
 ----------
 
-- Huan He, Mayo Clinic
-- Natthawut	(Max) Adulvanukosol, University of North Carolina at Chapel Hill
+- Huan He, Yale University
+- Natthawut	(Max) Adulyanukosol, University of North Carolina at Chapel Hill
 
 
 Special Issue Liaison
@@ -76,4 +76,38 @@ Steering Committee
 International Program Committee
 ===============================
 
-- TBD
+- Adriana Arcia, Columbia University School of Nursing
+- Alessio Arleo, TU Wien
+- Alexander Rind, St. Poelten University of Applied Sciences
+- Barbora Kozlíková, Masaryk University
+- BC Kwon, IBM Research
+- Bernhard Preim, University of Magdeburg
+- Brian Fisher, Simon Fraser
+- David Borland, RENCI
+- Eduard Gröller, Vienna University of Technology
+- Fabio Kon, University of Sao Paulo
+- Francisco Maria Calisto, IST - U. Lisboa
+- Harry Hochheiser, University of Pittsburgh
+- Huan He, Yale University
+- Ignacio Perez Messina, Vienna University of Technology
+- Jan Byška, University of Bergen
+- Jeremy Warner, Vanderbilt University
+- Jörn Kohlhammer, Fraunhofer IGD
+- Kai Lawonn, University of Jena
+- Kendall Ho, University of British Columbia
+- Kresimir Matkovic, VRVis
+- Max Sondag, University of Cologne
+- Meghan Turchioe, Weill Cornell Medicine
+- Ming Huang, Mayo Clinic
+- Nikolaus Piccolotto, Vienna University of Technology
+- Nils Gehlenborg, Harvard Medical School
+- Paul Rosenthal, University of Rostock
+- Renata Georgia Raidou, Vienna University of Technology
+- Robert Laramee, University of Nottingham
+- Roy Ruddle, University of Leeds
+- Silvia Miksch, TU Wien
+- Timo Ropinski, Ulm University
+- Tobias, Schreck
+- Velitchko Filipov, Vienna University of Technology
+- Victor Schetinger, Vienna University of Technology
+- Yiran Li, University of California, Davis

--- a/content/2023/index.md
+++ b/content/2023/index.md
@@ -46,6 +46,7 @@ IMPORTANT DATES
 
 LATEST NEWS
 ===========
+- September 2023. The VAHC Workshop at IEEE VIS will be on Sunday, October 22, 2023: 2:00 PM-5:00 PM AEDT (UTC+11).
 - August 2023. We have accepted 11 submissions (6 papers and 5 posters/demos). Congratulations to all authors! 🎉
 - July 2023. New Special Issue on JAMIA on "Interactive Visualization of Health Data for Digital and Personal Health"
 - March 2022. Website migrated to GitHub.


### PR DESCRIPTION
Following Jürgen's request via email:

> - News: "September 2023. The VAHC Workshop at IEEE VIS will be on Sunday, October 22, 2023: 2:00 PM-5:00 PM AEDT (UTC+11)."
> - The final IPC List of the VAHC 2023